### PR TITLE
Stop the current video before starting a new one.

### DIFF
--- a/resources/lib/tubecast/youtube/player.py
+++ b/resources/lib/tubecast/youtube/player.py
@@ -20,6 +20,8 @@ class CastPlayer(xbmc.Player):
         self.from_yt = False
 
     def play_from_youtube(self, url):  # type: (str) -> None
+        if self.isPlaying():
+            self.stop()
         self.from_yt = True
         self.play(url)
 


### PR DESCRIPTION
This fixes the youtube app losing sync with the current playing video/position when starting a new video from the app while there was one already playing.